### PR TITLE
Fix openapi-generator handle nullable string for generated ue4-cpp

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-ue4/helpers-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-ue4/helpers-header.mustache
@@ -424,12 +424,19 @@ inline bool TryGetJsonValue(const TSharedPtr<FJsonValue>& JsonValue, TMap<FStrin
 }
 
 template<typename T>
-inline bool TryGetJsonValue(const TSharedPtr<FJsonObject>& JsonObject, const FString& Key, T& Value)
+inline bool TryGetJsonValue(const TSharedPtr<FJsonObject>& JsonObject, const FString& Key, T& Value, const bool IsNullable = false)
 {
 	const TSharedPtr<FJsonValue> JsonValue = JsonObject->TryGetField(Key);
-	if (JsonValue.IsValid() && !JsonValue->IsNull())
+	if (JsonValue.IsValid())
 	{
-		return TryGetJsonValue(JsonValue, Value);
+		if (JsonValue->IsNull())
+		{
+			return IsNullable;	// assume parsing null string successfully by IsNullable
+		}
+		else
+		{
+			return TryGetJsonValue(JsonValue, Value);
+		}
 	}
 	return false;
 }

--- a/modules/openapi-generator/src/main/resources/cpp-ue4/model-source.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-ue4/model-source.mustache
@@ -177,7 +177,7 @@ bool {{classname}}::FromJson(const TSharedPtr<FJsonValue>& JsonValue)
 
 	{{#vars}}
 	{{#required}}
-	{{^isWriteOnly}}ParseSuccess &= {{/isWriteOnly}}TryGetJsonValue(*Object, TEXT("{{baseName}}"), {{name}});
+	{{^isWriteOnly}}ParseSuccess &= {{/isWriteOnly}}TryGetJsonValue(*Object, TEXT("{{baseName}}"), {{name}}, {{isNullable}});
 	{{/required}}
 	{{^required}}
 	ParseSuccess &= TryGetJsonValue(*Object, TEXT("{{baseName}}"), {{name}});


### PR DESCRIPTION
Fix openapi-generator handle nullable string for generated ue4-cpp
